### PR TITLE
Add bootstrap script for memory bank templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,29 @@ For a detailed explanation of how Memory Bank implements these principles, see t
 
 - **AI Model**: Claude 4 Sonnet or Claude 4 Opus is recommended for best results, especially for CREATIVE mode's "Think" tool methodology.
 
+### Step 0: Bootstrap the Memory Bank files
+
+Before activating any custom modes, create the working Memory Bank documents for your project. Run the bootstrap script from the repository root and point it to the directory where you want the files to live (for example, your project's `.cursor/memory_bank/` folder):
+
+```
+python tools/bootstrap_memory_bank.py --dest /path/to/your/project/memory_bank
+```
+
+The script creates four files if they do not exist:
+
+- `tasks.md`
+- `progress.md`
+- `activeContext.md`
+- `projectbrief.md`
+
+To confirm they are ready before switching modes, list the directory or open the files directly:
+
+```
+ls /path/to/your/project/memory_bank
+```
+
+If you need to regenerate the templates, rerun the command with `--force` to overwrite existing files.
+
 ### Step 1: Get the Files
 
 Simply clone this repository into your project directory:

--- a/templates/memory_bank/activeContext.md
+++ b/templates/memory_bank/activeContext.md
@@ -1,0 +1,20 @@
+# 🧠 Active Context Summary
+
+Capture only the information that the agent must remember between mode switches. Purge or archive anything outdated.
+
+## 🔍 Current Focus
+- **Task ID**: _Reference from tasks.md_
+- **Why it matters**: _Impact or reasoning_
+
+## 📚 Key References
+- _File paths, PRDs, specs that are essential right now_
+
+## ⚙️ Technical Decisions
+- _Document finalized choices (frameworks, patterns, interfaces)_
+- _Link to supporting discussion if applicable_
+
+## 🧪 Verification Notes
+- _Tests to run before claiming completion_
+- _Metrics or acceptance criteria_
+
+> **Maintenance Rule:** When the focus shifts, move stale context to a historical log (e.g. `archive/activeContext-2024-05-01.md`) to keep this file lean.

--- a/templates/memory_bank/progress.md
+++ b/templates/memory_bank/progress.md
@@ -1,0 +1,21 @@
+# 🚦 Memory Bank Progress Log
+
+Track incremental progress, blockers, and planned next steps. Keep entries short but specific.
+
+## 📅 Daily Snapshot
+- **Date**: _YYYY-MM-DD_
+- **Mode**: _Which mode you are currently in_
+- **Focus**: _One sentence summary of what is being tackled_
+
+## 📈 Updates
+- _e.g. Implemented authentication middleware and added unit tests_
+- _e.g. Coordinated with design for dashboard mockups_
+
+## 🧱 Blockers / Risks
+- _List anything that could delay completion_
+
+## 🔜 Next Actions
+1. _Immediate follow-up task_
+2. _Secondary task if time remains_
+
+> **Tip:** Reference task IDs from `tasks.md` whenever possible to keep the documentation synchronized.

--- a/templates/memory_bank/projectbrief.md
+++ b/templates/memory_bank/projectbrief.md
@@ -1,0 +1,32 @@
+# 📘 Project Brief Template
+
+Summarize the project scope so new collaborators (or future you) can get up to speed quickly.
+
+## 🏷 Basic Info
+- **Project Name**: _Working title_
+- **Stakeholders**: _Who cares about the outcome_
+- **Timeline / Milestones**: _Key dates or iteration windows_
+
+## 🧩 Problem Statement
+_Describe the pain point or opportunity driving the work._
+
+## 🎯 Objectives & Success Criteria
+- _Objective 1 — measurable outcome_
+- _Objective 2 — measurable outcome_
+
+## 🗺 Scope Overview
+- **In Scope**: _Primary features, user flows, or components_
+- **Out of Scope**: _What you intentionally will not build_
+
+## 🛠 Technical Landscape
+- **Existing Systems**: _Integrations, dependencies_
+- **Constraints**: _Tech debt, performance requirements, compliance_
+
+## 👥 Users & Use Cases
+- _Persona or role_: _What they need from the system_
+- _Persona or role_: _What they need from the system_
+
+## 📎 Supporting Materials
+- _Links to design docs, tickets, repos, or prior art_
+
+> **Reminder:** Keep this brief living—refresh when priorities shift and record major decisions that influence scope.

--- a/templates/memory_bank/tasks.md
+++ b/templates/memory_bank/tasks.md
@@ -1,0 +1,28 @@
+# 🧭 Memory Bank Task Tracker
+
+Use this file as the single source of truth for planning and execution. Update it every time the scope changes or a phase is completed.
+
+## 🚀 Mission Overview
+- **Project Name**: _e.g. "Inventory Service"_
+- **Complexity Level**: _L1–L4_
+- **Primary Goal**: _One sentence outcome statement_
+
+## 🎯 Active Task
+- **Task ID**: _Unique short label_
+- **Mode / Phase**: _VAN, PLAN, CREATIVE, IMPLEMENT, REFLECT, ARCHIVE_
+- **Status**: _PLANNING · IN_PROGRESS · BLOCKED · REVIEW · COMPLETE_
+- **Notes**: _Key context, blockers, decisions_
+
+## 📋 Task Backlog
+| ID | Title | Owner | Status | Next Checkpoint |
+|----|-------|-------|--------|-----------------|
+| T-001 | _Define API schema_ | _You_ | _PLANNING_ | _After PLAN mode review_
+| ... | ... | ... | ... | ... |
+
+## ✅ Completion Checklist
+- [ ] Plan documented and linked
+- [ ] Dependencies resolved
+- [ ] Tests or validation steps defined
+- [ ] Handover or follow-up tasks captured
+
+> **Reminder:** Before switching modes, confirm this file reflects the latest reality. Other Memory Bank files should reference the information consolidated here.

--- a/tools/bootstrap_memory_bank.py
+++ b/tools/bootstrap_memory_bank.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Bootstrap Memory Bank working files from templates."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates" / "memory_bank"
+TEMPLATE_FILES = [
+    "tasks.md",
+    "progress.md",
+    "activeContext.md",
+    "projectbrief.md",
+]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Copy Memory Bank templates into a project directory."
+    )
+    parser.add_argument(
+        "--dest",
+        required=True,
+        help="Destination directory where Memory Bank files should be created.",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing files if they are already present.",
+    )
+    return parser.parse_args()
+
+
+def ensure_template_dir_exists() -> None:
+    if not TEMPLATE_DIR.exists():
+        sys.stderr.write(
+            f"Template directory not found at {TEMPLATE_DIR}. Did you move the project files?\n"
+        )
+        raise SystemExit(1)
+
+
+def copy_templates(destination: Path, force: bool) -> None:
+    created = []
+    skipped = []
+    overwritten = []
+
+    for filename in TEMPLATE_FILES:
+        source = TEMPLATE_DIR / filename
+        if not source.exists():
+            sys.stderr.write(f"Missing template: {source}\n")
+            raise SystemExit(1)
+
+        target = destination / filename
+        existed_before_copy = target.exists()
+
+        if existed_before_copy and not force:
+            skipped.append(target)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(source, target)
+        if existed_before_copy:
+            overwritten.append(target)
+        else:
+            created.append(target)
+
+    for path in created:
+        print(f"Created {path}")
+    for path in overwritten:
+        print(f"Overwrote {path}")
+    for path in skipped:
+        print(f"Skipped {path} (already exists)")
+
+    summary_parts = []
+    if created:
+        summary_parts.append(f"created {len(created)}")
+    if overwritten:
+        summary_parts.append(f"overwrote {len(overwritten)}")
+    if skipped:
+        summary_parts.append(f"skipped {len(skipped)} existing")
+
+    if summary_parts:
+        print("Summary: " + ", ".join(summary_parts))
+    else:
+        print("No files processed.")
+
+
+def main() -> None:
+    args = parse_args()
+    ensure_template_dir_exists()
+
+    destination = Path(args.dest).expanduser()
+    if destination.exists() and not destination.is_dir():
+        sys.stderr.write(
+            f"Destination '{destination}' exists and is not a directory. Aborting.\n"
+        )
+        raise SystemExit(1)
+
+    destination.mkdir(parents=True, exist_ok=True)
+    copy_templates(destination, force=args.force)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add reusable Memory Bank markdown templates for core working documents
- provide a bootstrap utility that copies the templates into a target project with an optional overwrite flag
- document a new setup step describing how to run the bootstrap script and verify the generated files

## Testing
- python tools/bootstrap_memory_bank.py --dest /tmp/memory_bank_demo

------
https://chatgpt.com/codex/tasks/task_e_68d973c7c57c8333bbdd028748c205a8