### PR TITLE
Fix typo in reflect mode section

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For each mode, configure as follows (If MCPs are showing, you can keep them on, 
 
 <img src="assets/implement_mode_1.png" height="300"/> <img src="assets/implement_mode_2.png" height="300" style="display: inline-block;"/>
 
-5. **REFLECT & ARHIVE MODE** (Review)
+5. **REFLECT & ARCHIVE MODE** (Review)
    - **Name**: 🔍 REFLECT or ARCHIVE
    - **Tools**: Enable "Codebase Search", "Read File", "Terminal", "List Directory"
    - **Advanced options**: Paste from `custom_modes/reflect_archive_instructions.md`


### PR DESCRIPTION
## Summary
- correct the REFLECT & ARCHIVE mode heading typo in README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d973cbbe4c83338a55e37376d9c209