### PR TITLE
Fix spelling in REFLECT & ARCHIVE setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ For each mode, configure as follows (If MCPs are showing, you can keep them on, 
 
 <img src="assets/implement_mode_1.png" height="300"/> <img src="assets/implement_mode_2.png" height="300" style="display: inline-block;"/>
 
-5. **REFLECT & ARHIVE MODE** (Review)
+5. **REFLECT & ARCHIVE MODE** (Review)
    - **Name**: 🔍 REFLECT or ARCHIVE
    - **Tools**: Enable "Codebase Search", "Read File", "Terminal", "List Directory"
    - **Advanced options**: Paste from `custom_modes/reflect_archive_instructions.md`
@@ -185,7 +185,7 @@ For each mode, configure as follows (If MCPs are showing, you can keep them on, 
 <img src="assets/reflect_mode_1.png" height="300"/> <img src="assets/reflect_mode_2.png" height="300" style="display: inline-block;"/>
    
 
-> **Note**: REFLECT and ARCHIVE instructions are combined in a single file and mode to optimize for Cursor's character and custom mode limits  while maintaining functionality. Thanks to GitHub user @joshmac007 for implementing this optimization.
+> **Note**: REFLECT and ARCHIVE instructions are combined in a single file and mode to optimize for Cursor's character and custom mode limits while maintaining functionality. Thanks to GitHub user @joshmac007 for implementing this optimization.
 
 For additional help on setting up custom modes in Cursor, refer to the [official Cursor documentation on custom modes](https://docs.cursor.com/chat/custom-modes).
 


### PR DESCRIPTION
## Summary
- correct the REFLECT mode heading to say "REFLECT & ARCHIVE MODE"
- fix spacing in the adjacent note for consistent grammar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d973d25a7883338dcd21d12577f200